### PR TITLE
macos CI: test arm64 cli

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,3 @@
-
 name: macOS Build
 on:
   push:
@@ -212,10 +211,7 @@ jobs:
         run: |
           cd build 
           sudo cp -R RawTherapee.app /Applications
-          open -a RawTherapee
-          sleep 5
-          osascript -e 'tell application "Finder"' -e 'get the name of every process whose visible is true' -e 'end tell'
-          osascript -e 'tell application "RawTherapee" to if it is running then quit'
+          time RawTherapee_*/rawtherapee-cli
       - name: Publish artifacts
         uses: softprops/action-gh-release@v2
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}


### PR DESCRIPTION
Instead of test-launching the arm64 app, test-launches the -cli instead.